### PR TITLE
bugfix #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/scripts/Bootstrap.sh
+++ b/scripts/Bootstrap.sh
@@ -15,6 +15,6 @@ ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -N '' <<< 'y'
 
 # installing zip and unzip needed for jenkins plugin script
 echo "======= Installing Zip & Unzip ======"
-sudo apt-get install zip unzip
+sudo apt-get install -y zip unzip
 echo "======= Installing sshpass ======"
-sudo apt-get install sshpass
+sudo apt-get install -y --force-yes sshpass


### PR DESCRIPTION
Add automatic "yes" to "apt-get install" as answer to all prompts and run non-interactively.
Force installing sshpass even if the package cannot be verified.
